### PR TITLE
Build on bytecode-only compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,12 @@ SELECT_CMD=$(shell ocaml select_version.ml $(OCAML_VERSION))
 select:
 	$(SELECT_CMD)
 
-TARGETS=$(addprefix src/, seq.cma seq.cmxa seq.cmxs)
+OCAMLOPT := $(shell ocamlopt -version)
+ifdef OCAMLOPT
+	NATIVE_TARGETS := seq.cmxa seq.cmxs
+endif
+
+TARGETS=$(addprefix src/, seq.cma $(NATIVE_TARGETS))
 build: select
 	ocamlbuild $(TARGETS)
 


### PR DESCRIPTION
On 4.05.0+bytecode-only without this patch:

```
$ opam install seq
# + ocamlopt -c -g -I src -o src/seq.cmx src/seq.ml
# /bin/sh: 1: ocamlopt: not found
# Command exited with code 127.
# Makefile:12: recipe for target 'build' failed
# make: *** [build] Error 10
```

With this patch:

```
$ opam install seq
Done.
```

I installed Lwt on 4.05.0+bytecode-only using the patched seq, and it seems to work fine.

Also confirmed that the patched seq still works on regular switches, again by installing Lwt and running its tests. I also looked in `lib/seq/` to check that the `cmxa` and `cmxs` files are present. The switch was the regular 4.05.0.

I tried to write the code in such a way that it will not break on Windows. In particular, it doesn't assume a `which` command, or the name `/dev/null`. As a result, it prints one line to standard error if `ocamlopt` is not found. However, that line is probably not shown by most package managers. In particular, it has no effect on the opam output.