### PR TITLE
remove the ocaml version constraint from the opam file

### DIFF
--- a/seq.opam
+++ b/seq.opam
@@ -10,9 +10,7 @@ build: [
 ]
 depends: [
   "dune" {>= "1.1.0"}
-  # opam-repo contains a version for 4.07 and above that does nothing,
-  # because OCaml starts having a `Seq` module in the stdlib
-  "ocaml" {< "4.07.0"}
+  "ocaml"
 ]
 tags: [ "iterator" "seq" "pure" "list" "compatibility" "cascade" ]
 homepage: "https://github.com/c-cube/seq/"


### PR DESCRIPTION
This version of the package includes a compatibility version of the Seq module, and so compiles on 4.07+ as well.

- When installing with opam, it will not be selected as seq.base will be used.
- However, when installing as a duniverse monorepo, it is useful to have this repository directly used, since opam is not present to install the `seq` dummy file.

