### PR TITLE
Fix testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,17 +8,15 @@ jobs:
       matrix:
         #operating-system: [macos-latest, ubuntu-latest, windows-latest]
         operating-system: [ubuntu-latest, windows-latest]
-        ocaml-version:
+        ocaml-compiler:
           - 4.06.x
           - 4.07.x
           - 4.14.x
     steps:
     - uses: actions/checkout@master
-    - uses: avsm/setup-ocaml@master
+    - uses: ocaml/setup-ocaml@v2
       with:
-        ocaml-version: ${{ matrix.ocaml-version }}
-    - run: opam pin -n .
-    - run: opam depext -yt seq
+        ocaml-compiler: ${{ matrix.ocaml-compiler }}
     - run: opam install -t . --deps-only
     - run: opam exec -- dune build
     - run: opam exec -- dune runtest

--- a/test/t.ml
+++ b/test/t.ml
@@ -7,8 +7,6 @@ let s0_10 : int Seq.t =
   mk 0
 
 let () =
-  let s = Seq.append Seq.empty s0_10  in
-  assert (Seq.length s = 11);
-  let sum = Seq.fold_left (+) 0 s in
+  let sum = Seq.fold_left (+) 0 s0_10 in
   Printf.printf "sum: %d\n" sum;
   assert (sum = 55)


### PR DESCRIPTION
### Changes
1. Fix input to setup-ocaml GitHub Action. Currently they all silently tested with OCaml 4.14: https://github.com/c-cube/seq/runs/7469813990?check_suite_focus=true#step:3:611. (Yet another victim of https://github.com/ocaml/setup-ocaml/issues/585)
2. Fix test to not use `Seq.append` and `Seq.length`, which the package does not provide for old OCaml versions.

The hand-written opam file isn't great either, because it doesn't run the tests, so opam-repository CI also couldn't catch the problem in the test itself.